### PR TITLE
stop the preceding cron job for 時報 on reconnect

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -96,7 +96,8 @@ class bot {
             this.connect()
         })
 
-        jihou(this)
+        this.jihou?.stop()
+        this.jihou = jihou(this)
     }
 
     reply(text) {

--- a/src/jihou.js
+++ b/src/jihou.js
@@ -2,7 +2,7 @@ const moment = require("moment-timezone")
 const cron = require("node-cron")
 
 module.exports = (bot) => {
-    cron.schedule("0 0 * * * *", () => {
+    return cron.schedule("0 0 * * * *", () => {
         bot.reply(
             `[時報] ${moment()
                 .tz("Asia/Tokyo")


### PR DESCRIPTION
再接続のたびにjobが追加登録されて複数回時報が流れるバグを修正しました。
ES2020のオプショナルチェーンを使用しているので、ES2019以前で動作させる場合は適宜書き換えてください。